### PR TITLE
[Agent] :sparkles: Prettierの設定追加とformatOnSaveの有効化

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,21 @@
+# ビルド出力
+.cache
+build
+dist
+
+# 依存関係
+node_modules
+
+# ロックファイル
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# 環境変数
+.env
+.env.*
+
+# その他
+.github
+.vscode
+.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,28 @@
 {
   "cSpell.words": [
     "Hokori"
-  ]
+  ],
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ npm run dev
 
 アプリケーションは `http://localhost:5173` で利用できます。
 
+### コードフォーマット
+
+このプロジェクトではコードの一貫性を保つために Prettier を使用しています。
+
+```bash
+# すべてのファイルをフォーマット
+npm run format
+
+# フォーマットチェックのみ実行
+npm run format:check
+```
+
+#### エディタ設定
+
+VSCode を使用している場合は、以下の拡張機能をインストールすることをお勧めします：
+
+- [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+
+`.vscode/settings.json` で保存時に自動フォーマットが有効になっています。
+
 ### ビルド
 
 ```bash

--- a/app/app.css
+++ b/app/app.css
@@ -1,8 +1,9 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans:
+    'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
 html {

--- a/app/components/blog/blog-card.tsx
+++ b/app/components/blog/blog-card.tsx
@@ -1,25 +1,23 @@
-import React from "react";
-import { Link } from "react-router";
-import { Tag } from "../common/tag";
-import type { Article } from "~/types";
+import React from 'react';
+import { Link } from 'react-router';
+import { Tag } from '../common/tag';
+import type { Article } from '~/types';
 
-type Props = Article
+type Props = Article;
 
 export const BlogCard = ({ title, slug, tags, createDate, updateDate, previewContent }: Props) => {
-
-
   return (
     <div className="p-4 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors">
       <Link to={`/${slug}`} className="block">
         <h3 className="text-lg font-semibold mb-2 text-white truncate">{title}</h3>
 
-        {tags && <div className="flex flex-wrap gap-2 mb-3">
-          {tags.map(tag => (
-            <Tag key={tag} name={tag} />
-          ))}
-        </div>
-        }
-
+        {tags && (
+          <div className="flex flex-wrap gap-2 mb-3">
+            {tags.map(tag => (
+              <Tag key={tag} name={tag} />
+            ))}
+          </div>
+        )}
 
         {createDate && (
           <div className="text-sm text-gray-400 mb-2">
@@ -30,10 +28,8 @@ export const BlogCard = ({ title, slug, tags, createDate, updateDate, previewCon
           </div>
         )}
 
-        {previewContent && (
-          <p className="text-gray-300 line-clamp-2 text-sm">{previewContent}</p>
-        )}
+        {previewContent && <p className="text-gray-300 line-clamp-2 text-sm">{previewContent}</p>}
       </Link>
     </div>
   );
-}
+};

--- a/app/components/common/tag.tsx
+++ b/app/components/common/tag.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 export interface TagProps {
   name: string;
@@ -6,7 +6,7 @@ export interface TagProps {
   className?: string;
 }
 
-export function Tag({ name, onClick, className = "" }: TagProps) {
+export function Tag({ name, onClick, className = '' }: TagProps) {
   const handleClick = () => {
     if (onClick) {
       onClick(name);

--- a/app/components/layout/main-layout.tsx
+++ b/app/components/layout/main-layout.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Sidebar } from "./sidebar";
+import React from 'react';
+import { Sidebar } from './sidebar';
 
 export interface MainLayoutProps {
   children: React.ReactNode;
@@ -14,7 +14,7 @@ export function MainLayout({
   tags = [],
   selectedTag,
   onTagSelect,
-  onSearch
+  onSearch,
 }: MainLayoutProps) {
   return (
     <div className="flex min-h-screen bg-gray-900">
@@ -25,9 +25,7 @@ export function MainLayout({
         onSearch={onSearch}
       />
 
-      <main className="flex-grow p-4 md:p-8 pt-16 md:pt-8 overflow-auto">
-        {children}
-      </main>
+      <main className="flex-grow p-4 md:p-8 pt-16 md:pt-8 overflow-auto">{children}</main>
     </div>
   );
 }
@@ -37,9 +35,7 @@ export function Footer() {
     <footer className="py-6 px-4 md:px-8 border-t border-gray-800">
       <div className="flex flex-col md:flex-row justify-between items-center">
         <div className="mb-4 md:mb-0">
-          <p className="text-sm text-gray-400">
-            © 2024 Hokori note
-          </p>
+          <p className="text-sm text-gray-400">© 2024 Hokori note</p>
         </div>
 
         <div className="flex items-center space-x-4">

--- a/app/components/layout/sidebar.tsx
+++ b/app/components/layout/sidebar.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { Link, useLocation } from "react-router";
-import { Tag } from "../common/tag";
+import React, { useState } from 'react';
+import { Link, useLocation } from 'react-router';
+import { Tag } from '../common/tag';
 
 export interface SidebarProps {
   tags?: string[];
@@ -11,7 +11,7 @@ export interface SidebarProps {
 
 export function Sidebar({ tags = [], onTagSelect, selectedTag, onSearch }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
   const location = useLocation();
 
   const toggleSidebar = () => {
@@ -50,12 +50,34 @@ export function Sidebar({ tags = [], onTagSelect, selectedTag, onSearch }: Sideb
         onClick={toggleSidebar}
       >
         {isOpen ? (
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
           </svg>
         ) : (
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 6h16M4 12h16M4 18h16"
+            />
           </svg>
         )}
       </button>
@@ -65,7 +87,10 @@ export function Sidebar({ tags = [], onTagSelect, selectedTag, onSearch }: Sideb
         className={`fixed inset-y-0 left-0 transform ${isOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 transition-transform duration-300 ease-in-out md:relative md:h-screen w-64 bg-gray-900 border-r border-gray-800 p-4 overflow-y-auto z-40`}
       >
         <div className="mb-8">
-          <Link to="/" className="text-2xl font-bold text-white hover:text-blue-400 transition-colors">
+          <Link
+            to="/"
+            className="text-2xl font-bold text-white hover:text-blue-400 transition-colors"
+          >
             Hokori note
           </Link>
         </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,21 +5,21 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "react-router";
+} from 'react-router';
 
-import type { Route } from "./+types/root";
-import "./app.css";
+import type { Route } from './+types/root';
+import './app.css';
 
 export const links: Route.LinksFunction = () => [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
+  { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous",
+    rel: 'preconnect',
+    href: 'https://fonts.gstatic.com',
+    crossOrigin: 'anonymous',
   },
   {
-    rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
+    rel: 'stylesheet',
+    href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
   },
 ];
 
@@ -46,15 +46,15 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "エラーが発生しました";
-  let details = "予期しないエラーが発生しました。";
+  let message = 'エラーが発生しました';
+  let details = '予期しないエラーが発生しました。';
   let stack: string | undefined;
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "エラー";
+    message = error.status === 404 ? '404' : 'エラー';
     details =
       error.status === 404
-        ? "リクエストされたページが見つかりませんでした。"
+        ? 'リクエストされたページが見つかりませんでした。'
         : error.statusText || details;
   } else if (import.meta.env.DEV && error && error instanceof Error) {
     details = error.message;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,3 +1,3 @@
-import { type RouteConfig, index } from "@react-router/dev/routes";
+import { type RouteConfig, index } from '@react-router/dev/routes';
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [index('routes/home.tsx')] satisfies RouteConfig;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { useLoaderData } from "react-router";
-import type { Route } from "./+types/home";
-import { MainLayout, BlogCard, Footer } from "../components";
-import type { Article } from "~/types";
-import { fetchObsidianArticles } from "~/services/github.server";
+import { useState } from 'react';
+import { useLoaderData } from 'react-router';
+import type { Route } from './+types/home';
+import { MainLayout, BlogCard, Footer } from '../components';
+import type { Article } from '~/types';
+import { fetchObsidianArticles } from '~/services/github.server';
 
 export async function loader() {
   try {
@@ -11,43 +11,44 @@ export async function loader() {
 
     if (!result.success) {
       return {
-        error: "GitHubからのデータ取得に失敗しました",
-        message: result.message
+        error: 'GitHubからのデータ取得に失敗しました',
+        message: result.message,
       };
     }
 
     return {
       files: result.articles,
       message: result.message,
-      success: true
+      success: true,
     };
   } catch (error) {
-    console.error("Error fetching from GitHub:", error);
+    console.error('Error fetching from GitHub:', error);
     return {
-      error: "GitHubからのデータ取得に失敗しました",
-      message: error instanceof Error ? error.message : "Unknown error",
-      success: false
+      error: 'GitHubからのデータ取得に失敗しました',
+      message: error instanceof Error ? error.message : 'Unknown error',
+      success: false,
     };
   }
 }
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "Hokori note" },
-    { name: "description", content: "Obsidianのノートを公開するブログ" },
+    { title: 'Hokori note' },
+    { name: 'description', content: 'Obsidianのノートを公開するブログ' },
   ];
 }
 
 export function Home() {
-  const data = useLoaderData<typeof loader>()
+  const data = useLoaderData<typeof loader>();
 
   const [selectedTag, setSelectedTag] = useState<string | undefined>(undefined);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState('');
 
   // すべての記事から一意のタグを抽出
-  const extractedTags: string[] = data.files && data.files.length
-    ? Array.from(new Set(data.files.flatMap(file => file.tags || [])))
-    : [];
+  const extractedTags: string[] =
+    data.files && data.files.length
+      ? Array.from(new Set(data.files.flatMap(file => file.tags || [])))
+      : [];
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);
@@ -63,9 +64,10 @@ export function Home() {
     const tagMatch = !selectedTag || file.tags.includes(selectedTag);
 
     // 検索クエリでフィルタリング
-    const queryMatch = !searchQuery ||
+    const queryMatch =
+      !searchQuery ||
       file.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (file.previewContent?.toLowerCase() || "").includes(searchQuery.toLowerCase());
+      (file.previewContent?.toLowerCase() || '').includes(searchQuery.toLowerCase());
 
     return tagMatch && queryMatch;
   });
@@ -91,15 +93,15 @@ export function Home() {
         <div>
           <h2 className="text-2xl font-bold mb-6">最新の記事</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredFiles.map((file) => (
+            {filteredFiles.map(file => (
               <BlogCard
                 key={file.sha || file.path}
                 title={file.title}
                 slug={file.slug}
                 tags={file.tags}
-                createDate={file.createDate || "不明"}
+                createDate={file.createDate || '不明'}
                 updateDate={file.updateDate}
-                previewContent={file.previewContent || "プレビューなし"}
+                previewContent={file.previewContent || 'プレビューなし'}
               />
             ))}
           </div>

--- a/app/services/github.server.ts
+++ b/app/services/github.server.ts
@@ -1,11 +1,11 @@
-import { Octokit } from "octokit";
-import type { Article, GitHubFile } from "~/types";
-import { parseObsidianArticle } from "~/utils/obsidian";
+import { Octokit } from 'octokit';
+import type { Article, GitHubFile } from '~/types';
+import { parseObsidianArticle } from '~/utils/obsidian';
 
 const GITHUB_REPO_OWNER = process.env.GITHUB_REPO_OWNER as string;
 const GITHUB_REPO_NAME = process.env.GITHUB_REPO_NAME as string;
 const GITHUB_CONTENT_PATH = process.env.GITHUB_CONTENT_PATH as string;
-const GITHUB_BRANCH = 'main'
+const GITHUB_BRANCH = 'main';
 
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
@@ -15,31 +15,37 @@ const octokit = new Octokit({
  * GitHubからObsidian記事のリストを取得する
  * @returns 記事のリスト
  */
-export async function fetchObsidianArticles(): Promise<{ articles: Article[], success: boolean, message: string }> {
+export async function fetchObsidianArticles(): Promise<{
+  articles: Article[];
+  success: boolean;
+  message: string;
+}> {
   try {
     // GitHubからファイル一覧を取得
     const files = await fetchArticles();
 
     // 各ファイルの内容を取得して記事オブジェクトに変換
-    const articlesPromises = files.map(async (file) => {
+    const articlesPromises = files.map(async file => {
       const content = await fetchFileContent(file);
       return parseObsidianArticle(file, content);
     });
 
     // 結果を待ち、nullでないものだけをフィルタリング
-    const articles = (await Promise.all(articlesPromises)).filter((article): article is Article => article !== null);
+    const articles = (await Promise.all(articlesPromises)).filter(
+      (article): article is Article => article !== null
+    );
 
     return {
       articles,
       success: true,
-      message: `${articles.length}件の記事を取得しました`
+      message: `${articles.length}件の記事を取得しました`,
     };
   } catch (error) {
-    console.error("記事の取得に失敗しました:", error);
+    console.error('記事の取得に失敗しました:', error);
     return {
       articles: [],
       success: false,
-      message: `記事の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}`
+      message: `記事の取得に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }
@@ -67,7 +73,7 @@ async function fetchArticles() {
   }
 
   // マークダウンファイルのみをフィルタリング
-  return data.filter(data => data.name.endsWith(".md"));
+  return data.filter(data => data.name.endsWith('.md'));
 }
 
 /**

--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -1,6 +1,4 @@
-import { Octokit } from "octokit";
-
-
+import { Octokit } from 'octokit';
 
 // GitHubへのアクセスを管理するサービス
 class GitHubService {
@@ -13,12 +11,12 @@ class GitHubService {
     const token = process.env.GITHUB_TOKEN;
 
     if (!token) {
-      throw new Error("GitHub token is not set in environment variables");
+      throw new Error('GitHub token is not set in environment variables');
     }
 
-    this.owner = process.env.GITHUB_REPO_OWNER || "";
-    this.repo = process.env.GITHUB_REPO_NAME || "";
-    this.contentPath = process.env.GITHUB_CONTENT_PATH || "";
+    this.owner = process.env.GITHUB_REPO_OWNER || '';
+    this.repo = process.env.GITHUB_REPO_NAME || '';
+    this.contentPath = process.env.GITHUB_CONTENT_PATH || '';
 
     this.octokit = new Octokit({
       auth: token,
@@ -38,13 +36,13 @@ class GitHubService {
 
       // レスポンスがファイル配列の場合
       if (Array.isArray(response.data)) {
-        return response.data
+        return response.data;
       }
 
       // 単一ファイルの場合は配列に変換
       return [response.data];
     } catch (error) {
-      console.error("Error fetching from GitHub:", error);
+      console.error('Error fetching from GitHub:', error);
       throw error;
     }
   }
@@ -54,7 +52,7 @@ class GitHubService {
    */
   async getMarkdownFiles(path: string = this.contentPath) {
     const files = await this.getContents(path);
-    return files.filter(file => file.type === "file" && file.name.endsWith(".md"));
+    return files.filter(file => file.type === 'file' && file.name.endsWith('.md'));
   }
 
   /**
@@ -69,13 +67,13 @@ class GitHubService {
       });
 
       if ('content' in response.data && 'encoding' in response.data) {
-        const { content, encoding } = response.data
+        const { content, encoding } = response.data;
         if (content && encoding === 'base64') {
           return Buffer.from(content, 'base64').toString('utf-8');
         }
       }
 
-      throw new Error("Invalid file content or encoding");
+      throw new Error('Invalid file content or encoding');
     } catch (error) {
       console.error(`Error fetching file content for ${path}:`, error);
       throw error;

--- a/app/types.ts
+++ b/app/types.ts
@@ -22,7 +22,7 @@ export interface GitHubFile {
   html_url: string | null;
   git_url: string | null;
   download_url: string | null;
-  type: "file" | "dir" | "symlink" | "submodule";
+  type: 'file' | 'dir' | 'symlink' | 'submodule';
   content?: string;
   encoding?: string;
 }

--- a/app/utils/obsidian.ts
+++ b/app/utils/obsidian.ts
@@ -1,15 +1,17 @@
-import type { Article, GitHubFile, ObsidianFrontMatter } from "~/types";
+import type { Article, GitHubFile, ObsidianFrontMatter } from '~/types';
 
 /**
  * マークダウン文字列からフロントマターとコンテンツを抽出する
  * @param markdown マークダウン文字列
  * @returns フロントマターとコンテンツのオブジェクト
  */
-export function extractFrontMatter(markdown: string): { frontMatter: ObsidianFrontMatter | null, content: string } {
+export function extractFrontMatter(markdown: string): {
+  frontMatter: ObsidianFrontMatter | null;
+  content: string;
+} {
   // フロントマターが存在するか確認（---で囲まれたYAML形式のブロック）
   const frontMatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
   const match = markdown.match(frontMatterRegex);
-
 
   if (!match) {
     // フロントマターが見つからない場合
@@ -27,7 +29,7 @@ export function extractFrontMatter(markdown: string): { frontMatter: ObsidianFro
 
     return { frontMatter, content };
   } catch (error) {
-    console.error("フロントマターのパースに失敗しました:", error);
+    console.error('フロントマターのパースに失敗しました:', error);
     return { frontMatter: null, content: markdown };
   }
 }
@@ -43,7 +45,7 @@ function parseFrontMatter(frontMatterString: string): ObsidianFrontMatter {
     tags: [],
     create_date: '',
     update_date: '',
-    uid: ''
+    uid: '',
   };
 
   try {
@@ -94,7 +96,7 @@ function parseFrontMatter(frontMatterString: string): ObsidianFrontMatter {
             frontMatter[key] = false;
           } else {
             // 文字列（引用符を削除）
-            frontMatter[key] = value.replace(/^["'](.*)["']$/, "$1");
+            frontMatter[key] = value.replace(/^["'](.*)["']$/, '$1');
           }
         } else {
           // 値がない場合は、次の行を確認して配列かどうか判断
@@ -122,7 +124,7 @@ function parseFrontMatter(frontMatterString: string): ObsidianFrontMatter {
  */
 export function extractPreviewContent(content: string, maxLength: number = 150): string {
   // 最初の段落または特定の長さを抽出
-  const text = content.split("\n\n")[0] || "";
+  const text = content.split('\n\n')[0] || '';
 
   // マークダウン記法を削除
   const plainText = text
@@ -133,7 +135,7 @@ export function extractPreviewContent(content: string, maxLength: number = 150):
 
   // 長すぎる場合は切り詰める
   if (plainText.length > maxLength) {
-    return plainText.substring(0, maxLength) + "...";
+    return plainText.substring(0, maxLength) + '...';
   }
 
   return plainText;
@@ -146,7 +148,6 @@ export function extractPreviewContent(content: string, maxLength: number = 150):
  * @returns 記事情報
  */
 export function parseObsidianArticle(file: GitHubFile, content: string): Article | null {
-
   // フロントマターとコンテンツを抽出
   const { frontMatter, content: markdownContent } = extractFrontMatter(content);
 
@@ -163,12 +164,13 @@ export function parseObsidianArticle(file: GitHubFile, content: string): Article
   }
 
   // タイトルを取得（フロントマターのtitleか、ファイル名）
-  const title = frontMatter.title || file.name.replace(".md", "");
+  const title = frontMatter.title || file.name.replace('.md', '');
 
   // スラッグを取得（aliasesの最初の値か、ファイル名をスラッグ化）
-  const slug = frontMatter.aliases && frontMatter.aliases.length > 0
-    ? frontMatter.aliases[0]
-    : file.name.replace(".md", "").toLowerCase().replace(/\s+/g, "-");
+  const slug =
+    frontMatter.aliases && frontMatter.aliases.length > 0
+      ? frontMatter.aliases[0]
+      : file.name.replace('.md', '').toLowerCase().replace(/\s+/g, '-');
 
   // タグを取得
   const tags = frontMatter.tags || [];
@@ -187,6 +189,6 @@ export function parseObsidianArticle(file: GitHubFile, content: string): Article
     uid: frontMatter.uid,
     content: markdownContent,
     sha: file.sha,
-    path: file.path
+    path: file.path,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^20",
         "@types/react": "^19.0.1",
         "@types/react-dom": "^19.0.1",
+        "prettier": "^3.5.3",
         "react-router-devtools": "^1.1.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2",
@@ -2285,6 +2286,22 @@
         "wrangler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-router/dev/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@react-router/express": {
@@ -5557,16 +5574,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\""
   },
   "dependencies": {
     "@react-router/node": "^7.4.0",
@@ -24,6 +26,7 @@
     "@types/node": "^20",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
+    "prettier": "^3.5.3",
     "react-router-devtools": "^1.1.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2",

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,4 +1,4 @@
-import type { Config } from "@react-router/dev/config";
+import type { Config } from '@react-router/dev/config';
 
 export default {
   // Config options...

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,7 +46,5 @@ export default {
       },
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'),
-  ],
-}
+  plugins: [require('@tailwindcss/typography')],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "include": [
-    "**/*",
-    "**/.server/**/*",
-    "**/.client/**/*",
-    ".react-router/types/**/*"
-  ],
+  "include": ["**/*", "**/.server/**/*", "**/.client/**/*", ".react-router/types/**/*"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vite/client"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { reactRouter } from "@react-router/dev/vite";
-import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { reactRouter } from '@react-router/dev/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],


### PR DESCRIPTION
## 概要
Prettierの導入とformatOnSaveの設定

## 詳細
プロジェクトのコード品質とフォーマットの一貫性を維持するために以下の変更を行いました：

- Prettierをdevdependencyとして追加
- `.prettierrc`と`.prettierignore`の設定ファイルを追加
- VSCodeのformatOnSave設定の追加
- README.mdにPrettierの使用方法に関する情報を追加
- package.jsonにフォーマット用のスクリプトを追加
  - `npm run format` - 全ファイルをフォーマット
  - `npm run format:check` - フォーマットチェックのみを実行

## 期待する動作
- [ ] VSCodeでファイル保存時に自動的にフォーマットされる
- [ ] `npm run format`コマンドで全ファイルがフォーマットされる
- [ ] 全てのJS/TSファイルに一貫したフォーマットが適用される

## 参考
[Prettier公式ドキュメント](https://prettier.io/docs/en/)
